### PR TITLE
Add alternate recipes for technic concrete

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -376,4 +376,13 @@ minetest.register_craft({
 if minetest.get_modpath("technic") then
 	technic.register_grinder_recipe({input={"gloopblocks:pumice"},output="default:sand"})
 	technic.register_grinder_recipe({input={"gloopblocks:basalt"},output="default:cobble"})
+	minetest.register_craft({
+		type = "shapeless",
+		output = "technic:concrete 3",
+		recipe = {
+			"gloopblocks:wet_cement",
+			"group:sand",
+			"default:gravel",
+		}
+	})
 end


### PR DESCRIPTION
Shapeless crafting, one wet cement, one gravel, and one sand (any kind) produce 3 technic concrete. The gravel and sand are intended to represent aggregate, while the cement is, well, cement.